### PR TITLE
fix: make definition files compatible with IDEs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   moduleNameMapper: {
-    "^@rsql/(.*)$": "<rootDir>/packages/$1/src",
+    "^@rsql/(.*)$": "<rootDir>/packages/$1/dist",
   },
   globals: {
     "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap",
-    "clean": "lerna run --parallel clean",
     "build": "lerna run build",
     "release": "auto shipit -vv",
     "precommit": "lint-staged && yarn build && yarn test",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -19,9 +19,10 @@
     "ast"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
-    "compile": "tsc -b tsconfig.json && rollup -c && dts-bundle --name \"@rsql/ast\" --main lib/index.d.ts --out ../dist/index.d.ts",
-    "build": "yarn clean && yarn compile"
+    "build:clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
+    "build:lib": "tsc -b tsconfig.json",
+    "build:dist": "rollup -c && dts-bundle --name \"@rsql/ast\" --main lib/index.d.ts --out ../dist/index.d.ts --outputAsModuleFolder && prettier --write ./dist",
+    "build": "yarn build:clean && yarn build:lib && yarn build:dist"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/ast/tsconfig.json
+++ b/packages/ast/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib", "dist"]
 }

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -19,9 +19,10 @@
     "builder"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
-    "compile": "tsc -b tsconfig.json && rollup -c && dts-bundle --name \"@rsql/builder\" --main lib/index.d.ts --out ../dist/index.d.ts",
-    "build": "yarn clean && yarn compile"
+    "build:clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
+    "build:lib": "tsc -b tsconfig.json",
+    "build:dist": "rollup -c && dts-bundle --name \"@rsql/builder\" --main lib/index.d.ts --out ../dist/index.d.ts --outputAsModuleFolder && prettier --write ./dist",
+    "build": "yarn build:clean && yarn build:lib && yarn build:dist"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -19,84 +19,76 @@ import {
   ExpressionNode,
 } from "@rsql/ast";
 
-function comparison(
-  selector: string,
-  operator: ComparisonOperator,
-  value: string | number | (string | number)[]
-): ComparisonNode {
-  return createComparisonNode(
-    createSelectorNode(selector),
-    operator,
-    createValueNode(Array.isArray(value) ? value.map((singleValue) => String(singleValue)) : String(value))
-  );
+interface Builder {
+  comparison(
+    selector: string,
+    operator: ComparisonOperator,
+    value: string | number | (string | number)[]
+  ): ComparisonNode;
+  eq(selector: string, value: string | number): ComparisonNode;
+  neq(selector: string, value: string | number): ComparisonNode;
+  le(selector: string, value: string | number): ComparisonNode;
+  lt(selector: string, value: string | number): ComparisonNode;
+  ge(selector: string, value: string | number): ComparisonNode;
+  gt(selector: string, value: string | number): ComparisonNode;
+  in(selector: string, values: (string | number)[]): ComparisonNode;
+  out(selector: string, values: (string | number)[]): ComparisonNode;
+  logic(expressions: ExpressionNode[], operator: LogicOperator): ExpressionNode;
+  and(...expressions: ExpressionNode[]): ExpressionNode;
+  or(...expressions: ExpressionNode[]): ExpressionNode;
 }
 
-function eq(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, EQ, value);
-}
-
-function neq(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, NEQ, value);
-}
-
-function le(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, LE, value);
-}
-
-function lt(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, LT, value);
-}
-
-function ge(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, GE, value);
-}
-
-function gt(selector: string, value: string | number): ComparisonNode {
-  return comparison(selector, GT, value);
-}
-
-function in_(selector: string, values: (string | number)[]): ComparisonNode {
-  return comparison(selector, IN, values);
-}
-
-function out(selector: string, values: (string | number)[]): ComparisonNode {
-  return comparison(selector, OUT, values);
-}
-
-function logic(expressions: ExpressionNode[], operator: LogicOperator): ExpressionNode {
-  if (!expressions.length) {
-    throw new Error(`The logic expression builder requires at least one expression but none passed.`);
-  }
-
-  return expressions
-    .slice(1)
-    .reduce(
-      (leftExpression, rightExpression) => createLogicNode(leftExpression, operator, rightExpression),
-      expressions[0]
+const builder: Builder = {
+  comparison(selector, operator, value) {
+    return createComparisonNode(
+      createSelectorNode(selector),
+      operator,
+      createValueNode(Array.isArray(value) ? value.map((singleValue) => String(singleValue)) : String(value))
     );
-}
+  },
+  eq(selector, value) {
+    return builder.comparison(selector, EQ, value);
+  },
+  neq(selector, value) {
+    return builder.comparison(selector, NEQ, value);
+  },
+  le(selector, value) {
+    return builder.comparison(selector, LE, value);
+  },
+  lt(selector, value) {
+    return builder.comparison(selector, LT, value);
+  },
+  ge(selector, value) {
+    return builder.comparison(selector, GE, value);
+  },
+  gt(selector, value) {
+    return builder.comparison(selector, GT, value);
+  },
+  in(selector, values) {
+    return builder.comparison(selector, IN, values);
+  },
+  out(selector, values) {
+    return builder.comparison(selector, OUT, values);
+  },
+  logic(expressions, operator) {
+    if (!expressions.length) {
+      throw new Error(`The logic expression builder requires at least one expression but none passed.`);
+    }
 
-function and(...expressions: ExpressionNode[]): ExpressionNode {
-  return logic(expressions, AND);
-}
-
-function or(...expressions: ExpressionNode[]): ExpressionNode {
-  return logic(expressions, OR);
-}
-
-const builder = {
-  comparison,
-  eq,
-  neq,
-  le,
-  lt,
-  ge,
-  gt,
-  in: in_,
-  out,
-  logic,
-  and,
-  or,
+    return expressions
+      .slice(1)
+      .reduce(
+        (leftExpression, rightExpression) => createLogicNode(leftExpression, operator, rightExpression),
+        expressions[0]
+      );
+  },
+  and(...expressions) {
+    return builder.logic(expressions, AND);
+  },
+  or(...expressions) {
+    return builder.logic(expressions, OR);
+  },
 };
 
 export default builder;
+export { Builder };

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -6,5 +6,5 @@
     "outDir": "./lib"
   },
   "references": [{ "path": "../ast" }],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib", "dist"]
 }

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -19,9 +19,10 @@
     "emitter"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
-    "compile": "tsc -b tsconfig.json && rollup -c && dts-bundle --name \"@rsql/emitter\" --main lib/index.d.ts --out ../dist/index.d.ts",
-    "build": "yarn clean && yarn compile"
+    "build:clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
+    "build:lib": "tsc -b tsconfig.json",
+    "build:dist": "rollup -c && dts-bundle --name \"@rsql/emitter\" --main lib/index.d.ts --out ../dist/index.d.ts --outputAsModuleFolder && prettier --write ./dist",
+    "build": "yarn build:clean && yarn build:lib && yarn build:dist"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/emitter/tsconfig.json
+++ b/packages/emitter/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./lib"
   },
   "references": [{ "path": "../ast" }],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib", "dist"]
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -19,9 +19,10 @@
     "parser"
   ],
   "scripts": {
-    "clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
-    "compile": "tsc -b tsconfig.json && rollup -c && dts-bundle --name \"@rsql/parser\" --main lib/index.d.ts --out ../dist/index.d.ts",
-    "build": "yarn clean && yarn compile"
+    "build:clean": "rm -rf ./lib && rm -f tsconfig.tsbuildinfo && rm -rf ./dist",
+    "build:lib": "tsc -b tsconfig.json",
+    "build:dist": "rollup -c && dts-bundle --name \"@rsql/parser\" --main lib/index.d.ts --out ../dist/index.d.ts --outputAsModuleFolder && prettier --write ./dist",
+    "build": "yarn build:clean && yarn build:lib && yarn build:dist"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./lib"
   },
   "references": [{ "path": "../ast" }],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib", "dist"]
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.1-canary.5.ac4e45c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @rsql/ast@0.0.1-canary.5.ac4e45c.0
  npm install @rsql/builder@0.0.1-canary.5.ac4e45c.0
  npm install @rsql/emitter@0.0.1-canary.5.ac4e45c.0
  npm install @rsql/parser@0.0.1-canary.5.ac4e45c.0
  # or 
  yarn add @rsql/ast@0.0.1-canary.5.ac4e45c.0
  yarn add @rsql/builder@0.0.1-canary.5.ac4e45c.0
  yarn add @rsql/emitter@0.0.1-canary.5.ac4e45c.0
  yarn add @rsql/parser@0.0.1-canary.5.ac4e45c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
