### PR TITLE
bugfix: escape empty string

### DIFF
--- a/packages/emitter/src/index.ts
+++ b/packages/emitter/src/index.ts
@@ -44,6 +44,10 @@ function escapeQuotes(value: string, quote: string) {
 }
 
 function escapeValue(value: string, quote: '"' | "'" = '"') {
+  if (value === "") {
+    return quote + quote;
+  }
+
   if (ReservedChars.some((reservedChar) => value.includes(reservedChar))) {
     return `${quote}${escapeQuotes(value, quote)}${quote}`;
   }

--- a/tests/emitter/emit.spec.ts
+++ b/tests/emitter/emit.spec.ts
@@ -45,6 +45,15 @@ describe("emit", () => {
     }
   );
 
+  test('Empty string will be emitted as ""', () => {
+    const rsql = `selector==""`;
+    const ast = parse(rsql);
+    const emittedRsql = emit(ast);
+    const expectedRsql = `selector==""`;
+
+    expect(emittedRsql).toEqual(expectedRsql);
+  })
+
   it.each([
     ["(s0==a0,s1==a1);s2==a2", "(s0==a0,s1==a1);s2==a2"],
     ["(s0==a0 or s1==a1) and s2==a2", "(s0==a0 or s1==a1) and s2==a2"],


### PR DESCRIPTION
Our backend requires quoted empty string (`""`); as far as I understood the definition this is the correct behavior. This pull-request fixes the not escaped empty string.